### PR TITLE
Reintroduce type definitions to API graphs

### DIFF
--- a/javascript/ql/src/semmle/javascript/ApiGraphs.qll
+++ b/javascript/ql/src/semmle/javascript/ApiGraphs.qll
@@ -382,7 +382,7 @@ module API {
         or
         any(TypeAnnotation n).hasQualifiedName(m, _)
         or
-        any(Type t).hasUnderlyingType(m, _)
+        any(DataFlow::Node n).hasUnderlyingType(m, _)
       } or
       MkClassInstance(DataFlow::ClassNode cls) { cls = trackDefNode(_) and hasSemantics(cls) } or
       MkAsyncFuncResult(DataFlow::FunctionNode f) {
@@ -398,7 +398,7 @@ module API {
       MkTypeUse(string moduleName, string exportName) {
         any(TypeAnnotation n).hasQualifiedName(moduleName, exportName)
         or
-        any(Type t).hasUnderlyingType(moduleName, exportName)
+        exists(DataFlow::Node nd | nd.hasUnderlyingType(moduleName, exportName))
       } or
       MkSyntheticCallbackArg(DataFlow::Node src, int bound, DataFlow::InvokeNode nd) {
         trackUseNode(src, true, bound).flowsTo(nd.getCalleeNode())

--- a/javascript/ql/test/ApiGraphs/typescript-test/ApiGraph.expected
+++ b/javascript/ql/test/ApiGraphs/typescript-test/ApiGraph.expected
@@ -1,0 +1,19 @@
+#-----| root
+#-----| module mongoose -> use (module mongoose)
+#-----| module typescript-test -> def (module typescript-test)
+
+#-----| def (module typescript-test)
+#-----| member exports -> def (member exports (module typescript-test))
+
+#-----| use (module mongoose)
+#-----| member exports -> use (member exports (module mongoose))
+
+#-----| def (member exports (module typescript-test))
+#-----| member Sized -> def (member Sized (member exports (module typescript-test)))
+
+#-----| use (member exports (module mongoose))
+#-----| member Model -> use (member Model (member exports (module mongoose)))
+
+#-----| def (member Sized (member exports (module typescript-test)))
+
+#-----| use (member Model (member exports (module mongoose)))

--- a/javascript/ql/test/ApiGraphs/typescript-test/ApiGraph.ql
+++ b/javascript/ql/test/ApiGraphs/typescript-test/ApiGraph.ql
@@ -1,0 +1,61 @@
+/**
+ * @name API graph
+ * @description Shows the API graph of a code base.
+ * @kind graph
+ * @id js/api-graph
+ */
+
+import javascript
+
+/** Gets a string representation of the location information for `nd`. */
+string locationString(API::Node nd) {
+  exists(string fp, int sl, int sc, int el, int ec | nd.hasLocationInfo(fp, sl, sc, el, ec) |
+    result = fp + ":" + sl + ":" + sc + ":" + el + ":" + ec
+  )
+}
+
+/**
+ * Gets the rank of node `nd` among all nodes ordered by depth, string representation,
+ * and location.
+ */
+int nodeRank(API::Node nd) {
+  nd =
+    rank[result + 1](API::Node nd2 |
+      |
+      nd2 order by nd2.getDepth(), nd2.toString(), locationString(nd2)
+    )
+}
+
+/**
+ * Gets the rank of `lbl` among all labels on outgoing edges of `pred`, ordered alphabetically.
+ */
+int labelRank(API::Node pred, string lbl, API::Node succ) {
+  lbl + "->" + nodeRank(succ) =
+    rank[result + 1](string l, API::Node s |
+      s = pred.getASuccessor(l)
+      or
+      pred.refersTo(s) and l = ""
+    |
+      l + "->" + nodeRank(s)
+    )
+}
+
+query predicate nodes(API::Node f, string key, string value) {
+  key = "semmle.order" and
+  value = nodeRank(f).toString()
+}
+
+query predicate edges(API::Node pred, API::Node succ, string key, string value) {
+  exists(string lbl |
+    succ = pred.getASuccessor(lbl)
+    or
+    pred.refersTo(succ) and
+    lbl = ""
+  |
+    key = "semmle.label" and
+    value = lbl
+    or
+    key = "semmle.order" and
+    value = labelRank(pred, lbl, succ).toString()
+  )
+}

--- a/javascript/ql/test/ApiGraphs/typescript-test/index.ts
+++ b/javascript/ql/test/ApiGraphs/typescript-test/index.ts
@@ -1,0 +1,6 @@
+export interface Sized {
+  getSize(): number;
+}
+
+import * as mongoose from "mongoose";
+var myModel : mongoose.Model;

--- a/javascript/ql/test/ApiGraphs/typescript-test/package.json
+++ b/javascript/ql/test/ApiGraphs/typescript-test/package.json
@@ -1,0 +1,6 @@
+{
+    "name": "typescript-test",
+    "dependencies": {
+        "mongoose": "*"
+    }
+}

--- a/javascript/ql/test/ApiGraphs/typescript-test/tsconfig.json
+++ b/javascript/ql/test/ApiGraphs/typescript-test/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "include": ["."],
+  "compilerOptions": {
+    "esModuleInterop": true
+  }
+}


### PR DESCRIPTION
This adds back a representation of TypeScript type definitions, which should recover most of what `MkCanonicalTypeDef` was used for, but without the dependency on canonical names, which don't always exist.