### PR TITLE
Python: Split `def` and `use` nodes

### DIFF
--- a/python/ql/lib/semmle/python/frameworks/Aiomysql.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiomysql.qll
@@ -53,7 +53,7 @@ private module Aiomysql {
   class CursorExecuteCall extends SqlConstruction::Range, API::CallNode {
     CursorExecuteCall() { this = cursor().getMember("execute").getACall() }
 
-    override DataFlow::Node getSql() { result = this.getParameter(0, "operation").getARhs() }
+    override DataFlow::Node getSql() { result = this.getArgument(0, "operation").getARhs() }
   }
 
   /**
@@ -94,7 +94,7 @@ private module Aiomysql {
   class SAConnectionExecuteCall extends SqlConstruction::Range, API::CallNode {
     SAConnectionExecuteCall() { this = saConnection().getMember("execute").getACall() }
 
-    override DataFlow::Node getSql() { result = this.getParameter(0, "query").getARhs() }
+    override DataFlow::Node getSql() { result = this.getArgument(0, "query").getARhs() }
   }
 
   /**

--- a/python/ql/lib/semmle/python/frameworks/Aiopg.qll
+++ b/python/ql/lib/semmle/python/frameworks/Aiopg.qll
@@ -53,7 +53,7 @@ private module Aiopg {
   class CursorExecuteCall extends SqlConstruction::Range, API::CallNode {
     CursorExecuteCall() { this = cursor().getMember("execute").getACall() }
 
-    override DataFlow::Node getSql() { result = this.getParameter(0, "operation").getARhs() }
+    override DataFlow::Node getSql() { result = this.getArgument(0, "operation").getARhs() }
   }
 
   /**
@@ -90,7 +90,7 @@ private module Aiopg {
   class SAConnectionExecuteCall extends SqlConstruction::Range, API::CallNode {
     SAConnectionExecuteCall() { this = saConnection().getMember("execute").getACall() }
 
-    override DataFlow::Node getSql() { result = this.getParameter(0, "query").getARhs() }
+    override DataFlow::Node getSql() { result = this.getArgument(0, "query").getARhs() }
   }
 
   /**

--- a/python/ql/lib/semmle/python/frameworks/Asyncpg.qll
+++ b/python/ql/lib/semmle/python/frameworks/Asyncpg.qll
@@ -76,7 +76,7 @@ private module Asyncpg {
     class PreparedStatementConstruction extends SqlConstruction::Range, API::CallNode {
       PreparedStatementConstruction() { this = connection().getMember("prepare").getACall() }
 
-      override DataFlow::Node getSql() { result = this.getParameter(0, "query").getARhs() }
+      override DataFlow::Node getSql() { result = this.getArgument(0, "query").getARhs() }
     }
 
     class PreparedStatementExecution extends SqlExecution::Range, API::CallNode {
@@ -108,7 +108,7 @@ private module Asyncpg {
     class CursorConstruction extends SqlConstruction::Range, API::CallNode {
       CursorConstruction() { this = connection().getMember("cursor").getACall() }
 
-      override DataFlow::Node getSql() { result = this.getParameter(0, "query").getARhs() }
+      override DataFlow::Node getSql() { result = this.getArgument(0, "query").getARhs() }
     }
 
     /** The creation of a `Cursor` executes the associated query. */

--- a/python/ql/lib/semmle/python/frameworks/Requests.qll
+++ b/python/ql/lib/semmle/python/frameworks/Requests.qll
@@ -57,8 +57,8 @@ private module Requests {
     override predicate disablesCertificateValidation(
       DataFlow::Node disablingNode, DataFlow::Node argumentOrigin
     ) {
-      disablingNode = this.getKeywordParameter("verify").getARhs() and
-      argumentOrigin = this.getKeywordParameter("verify").getAValueReachingRhs() and
+      disablingNode = this.getKeywordArgument("verify").getARhs() and
+      argumentOrigin = this.getKeywordArgument("verify").getAValueReachingRhs() and
       argumentOrigin.asExpr().(ImmutableLiteral).booleanValue() = false and
       not argumentOrigin.asExpr() instanceof None
     }

--- a/python/ql/lib/semmle/python/frameworks/Stdlib.qll
+++ b/python/ql/lib/semmle/python/frameworks/Stdlib.qll
@@ -2507,7 +2507,7 @@ private module StdlibPrivate {
   /** Gets a call to `hashlib.new` with `algorithmName` as the first argument. */
   private API::CallNode hashlibNewCall(string algorithmName) {
     algorithmName =
-      result.getParameter(0, "name").getAValueReachingRhs().asExpr().(StrConst).getText() and
+      result.getArgument(0, "name").getAValueReachingRhs().asExpr().(StrConst).getText() and
     result = API::moduleImport("hashlib").getMember("new").getACall()
   }
 
@@ -2519,12 +2519,12 @@ private module StdlibPrivate {
 
     HashlibNewCall() {
       this = hashlibNewCall(hashName) and
-      exists(this.getParameter(1, "data"))
+      exists(this.getArgument(1, "data"))
     }
 
     override Cryptography::CryptographicAlgorithm getAlgorithm() { result.matchesName(hashName) }
 
-    override DataFlow::Node getAnInput() { result = this.getParameter(1, "data").getARhs() }
+    override DataFlow::Node getAnInput() { result = this.getArgument(1, "data").getARhs() }
   }
 
   /**

--- a/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
+++ b/python/ql/src/Security/CWE-295/RequestWithoutValidation.ql
@@ -19,7 +19,7 @@ from API::CallNode call, DataFlow::Node falseyOrigin, string verb
 where
   verb = HTTP::httpVerbLower() and
   call = API::moduleImport("requests").getMember(verb).getACall() and
-  falseyOrigin = call.getKeywordParameter("verify").getAValueReachingRhs() and
+  falseyOrigin = call.getKeywordArgument("verify").getAValueReachingRhs() and
   // requests treats `None` as the default and all other "falsey" values as `False`.
   falseyOrigin.asExpr().(ImmutableLiteral).booleanValue() = false and
   not falseyOrigin.asExpr() instanceof None

--- a/python/ql/test/TestUtilities/VerifyApiGraphs.qll
+++ b/python/ql/test/TestUtilities/VerifyApiGraphs.qll
@@ -70,7 +70,7 @@ class Assertion extends Comment {
     result =
       this.lookup(i - 1)
           .getASuccessor(any(API::Label::ApiLabel label |
-              label.toString() = this.getEdgeLabel(i - 1)
+              label.getLabelRelativeToNode(this.lookup(i - 1)) = this.getEdgeLabel(i - 1)
             ))
   }
 
@@ -89,7 +89,11 @@ class Assertion extends Comment {
         suffix =
           "it does have outgoing edges labelled " +
             concat(string lbl |
-              exists(nd.getASuccessor(any(API::Label::ApiLabel label | label.toString() = lbl)))
+              exists(
+                nd.getASuccessor(any(API::Label::ApiLabel label |
+                    label.getLabelRelativeToNode(nd) = lbl
+                  ))
+              )
             |
               lbl, ", "
             ) + "."

--- a/python/ql/test/library-tests/ApiGraphs/py3/deftest1.py
+++ b/python/ql/test/library-tests/ApiGraphs/py3/deftest1.py
@@ -1,29 +1,29 @@
 from mypkg import foo  #$ use=moduleImport("mypkg").getMember("foo")
 
-def callback(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("bar").getParameter(0).getParameter(0)
-    x.baz() #$ use=moduleImport("mypkg").getMember("foo").getMember("bar").getParameter(0).getParameter(0).getMember("baz").getReturn()
+def callback(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("bar").getArgument(0).getParameter(0)
+    x.baz() #$ use=moduleImport("mypkg").getMember("foo").getMember("bar").getArgument(0).getParameter(0).getMember("baz").getReturn()
 
-foo.bar(callback) #$ def=moduleImport("mypkg").getMember("foo").getMember("bar").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("bar").getReturn()
+foo.bar(callback) #$ def=moduleImport("mypkg").getMember("foo").getMember("bar").getArgument(0) use=moduleImport("mypkg").getMember("foo").getMember("bar").getReturn()
 
-def callback2(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("c").getParameter(0)
-    x.baz2() #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("c").getParameter(0).getMember("baz2").getReturn()
+def callback2(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("c").getParameter(0)
+    x.baz2() #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("c").getParameter(0).getMember("baz2").getReturn()
 
 mydict = {
-  "c": callback2, #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("c")
-  "other": "whatever" #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("other")
+  "c": callback2, #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("c")
+  "other": "whatever" #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("other")
 }
 
-foo.baz(mydict) #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("baz").getReturn()
+foo.baz(mydict) #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0) use=moduleImport("mypkg").getMember("foo").getMember("baz").getReturn()
 
-def callback3(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("third").getParameter(0)
-    x.baz3() #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("third").getParameter(0).getMember("baz3").getReturn()
+def callback3(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("third").getParameter(0)
+    x.baz3() #$ use=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("third").getParameter(0).getMember("baz3").getReturn()
 
-mydict.third = callback3 #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getParameter(0).getMember("third")
+mydict.third = callback3 #$ def=moduleImport("mypkg").getMember("foo").getMember("baz").getArgument(0).getMember("third")
 
-foo.blab(mydict) #$ def=moduleImport("mypkg").getMember("foo").getMember("blab").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("blab").getReturn()
+foo.blab(mydict) #$ def=moduleImport("mypkg").getMember("foo").getMember("blab").getArgument(0) use=moduleImport("mypkg").getMember("foo").getMember("blab").getReturn()
 
-def callback4(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("quack").getParameter(0).getParameter(0)
-    x.baz4() #$ use=moduleImport("mypkg").getMember("foo").getMember("quack").getParameter(0).getParameter(0).getMember("baz4").getReturn()
+def callback4(x): #$ use=moduleImport("mypkg").getMember("foo").getMember("quack").getArgument(0).getParameter(0)
+    x.baz4() #$ use=moduleImport("mypkg").getMember("foo").getMember("quack").getArgument(0).getParameter(0).getMember("baz4").getReturn()
 
 otherDict = {
     # TODO: Backtracking through a property set using a dict doesn't work, but I can backtrack through explicit property writes, e.g. the `otherDict.fourth` below.
@@ -32,30 +32,30 @@ otherDict = {
 }
 otherDict.fourth = callback4
 
-foo.quack(otherDict.fourth) #$ def=moduleImport("mypkg").getMember("foo").getMember("quack").getParameter(0) use=moduleImport("mypkg").getMember("foo").getMember("quack").getReturn()
+foo.quack(otherDict.fourth) #$ def=moduleImport("mypkg").getMember("foo").getMember("quack").getArgument(0) use=moduleImport("mypkg").getMember("foo").getMember("quack").getReturn()
 
-def namedCallback(myName, otherName): 
-    # Using named parameters: 
-    myName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getKeywordParameter("myName").getReturn()
-    otherName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getKeywordParameter("otherName").getReturn()
-    # Using numbered parameters: 
-    myName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getParameter(0).getReturn()
-    otherName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getParameter(0).getParameter(1).getReturn()
+def namedCallback(myName, otherName):
+    # Using named parameters:
+    myName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getArgument(0).getKeywordParameter("myName").getReturn()
+    otherName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getArgument(0).getKeywordParameter("otherName").getReturn()
+    # Using numbered parameters:
+    myName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getArgument(0).getParameter(0).getReturn()
+    otherName() #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getArgument(0).getParameter(1).getReturn()
 
 foo.blob(namedCallback) #$ use=moduleImport("mypkg").getMember("foo").getMember("blob").getReturn()
 
-foo.named(myName = 2) #$ def=moduleImport("mypkg").getMember("foo").getMember("named").getKeywordParameter("myName")
+foo.named(myName = 2) #$ def=moduleImport("mypkg").getMember("foo").getMember("named").getKeywordArgument("myName")
 
 
 def recusisionCallback(x):
-    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getParameter(0).getMember("callback").getParameter(0).getMember("recursion").getReturn()
-    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getParameter(0).getMember("rec1").getMember("callback").getParameter(0).getMember("recursion").getReturn()
-    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getParameter(0).getMember("rec1").getMember("rec2").getMember("callback").getParameter(0).getMember("recursion").getReturn()
-    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getParameter(0).getMember("rec1").getMember("rec2").getMember("rec1").getMember("callback").getParameter(0).getMember("recursion").getReturn()
+    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getArgument(0).getMember("callback").getParameter(0).getMember("recursion").getReturn()
+    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getArgument(0).getMember("rec1").getMember("callback").getParameter(0).getMember("recursion").getReturn()
+    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getArgument(0).getMember("rec1").getMember("rec2").getMember("callback").getParameter(0).getMember("recursion").getReturn()
+    x.recursion() #$ use=moduleImport("mypkg").getMember("foo").getMember("rec").getArgument(0).getMember("rec1").getMember("rec2").getMember("rec1").getMember("callback").getParameter(0).getMember("recursion").getReturn()
 
 recursiveDict = {};
 recursiveDict.callback = recusisionCallback;
 recursiveDict.rec1 = recursiveDict;
 recursiveDict.rec2 = recursiveDict;
 
-foo.rec(recursiveDict); #$ def=moduleImport("mypkg").getMember("foo").getMember("rec").getParameter(0)
+foo.rec(recursiveDict); #$ def=moduleImport("mypkg").getMember("foo").getMember("rec").getArgument(0)

--- a/python/ql/test/library-tests/ApiGraphs/py3/deftest2.py
+++ b/python/ql/test/library-tests/ApiGraphs/py3/deftest2.py
@@ -2,18 +2,18 @@
 
 from flask.views import View #$ use=moduleImport("flask").getMember("views").getMember("View")
 
-class MyView(View): #$ use=moduleImport("flask").getMember("views").getMember("View").getASubclass()
-    myvar = 45 #$ def=moduleImport("flask").getMember("views").getMember("View").getASubclass().getMember("myvar")
-    def my_method(self): #$ def=moduleImport("flask").getMember("views").getMember("View").getASubclass().getMember("my_method")
-        return 3 #$ def=moduleImport("flask").getMember("views").getMember("View").getASubclass().getMember("my_method").getReturn()
+class MyView(View): #$ use=moduleImport("flask").getMember("views").getMember("View").getASubclassUse()
+    myvar = 45 #$ def=moduleImport("flask").getMember("views").getMember("View").getASubclassUse().getMember("myvar")
+    def my_method(self): #$ def=moduleImport("flask").getMember("views").getMember("View").getASubclassUse().getMember("my_method")
+        return 3 #$ def=moduleImport("flask").getMember("views").getMember("View").getASubclassUse().getMember("my_method").getReturn()
 
-instance = MyView() #$ use=moduleImport("flask").getMember("views").getMember("View").getASubclass().getReturn()
+instance = MyView() #$ use=moduleImport("flask").getMember("views").getMember("View").getASubclassUse().getReturn()
 
 def internal():
     from pflask.views import View #$ use=moduleImport("pflask").getMember("views").getMember("View")
-    class IntMyView(View): #$ use=moduleImport("pflask").getMember("views").getMember("View").getASubclass()
-        my_internal_var = 35 #$ def=moduleImport("pflask").getMember("views").getMember("View").getASubclass().getMember("my_internal_var")
-        def my_internal_method(self): #$ def=moduleImport("pflask").getMember("views").getMember("View").getASubclass().getMember("my_internal_method")
+    class IntMyView(View): #$ use=moduleImport("pflask").getMember("views").getMember("View").getASubclassUse()
+        my_internal_var = 35 #$ def=moduleImport("pflask").getMember("views").getMember("View").getASubclassUse().getMember("my_internal_var")
+        def my_internal_method(self): #$ def=moduleImport("pflask").getMember("views").getMember("View").getASubclassUse().getMember("my_internal_method")
             pass
 
-    int_instance = IntMyView() #$ use=moduleImport("pflask").getMember("views").getMember("View").getASubclass().getReturn()
+    int_instance = IntMyView() #$ use=moduleImport("pflask").getMember("views").getMember("View").getASubclassUse().getReturn()


### PR DESCRIPTION
This demonstrates a way of splitting up the external API of API graphs
so that definitions and uses are distinguished. The internal
representation is unchanged.

With this change, we can enforce the use of `getParameter`/`getArgument`
and other methods to conform to whether the given node is a definition
or a use.

cc @yoff