### PR TITLE
patching 10 QL-for-QL issues

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql
@@ -266,7 +266,11 @@ class PathElement extends TPathElement {
   predicate isSink(IRBlock block) { exists(this.asSink(block)) }
 
   string toString() {
-    result = [asStore().toString(), asCall(_).toString(), asMid().toString(), asSink(_).toString()]
+    result =
+      [
+        this.asStore().toString(), this.asCall(_).toString(), this.asMid().toString(),
+        this.asSink(_).toString()
+      ]
   }
 
   predicate hasLocationInfo(

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
@@ -75,7 +75,7 @@ predicate signSmallerWithEqualSizes(MulExpr mexp) {
       ae.getRValue().getUnderlyingType().(IntegralType).isUnsigned() and
       ae.getLValue().getUnderlyingType().(IntegralType).isSigned() and
       (
-        not exists(DivExpr de | mexp.getParent*() = de)
+        not mexp.getParent*() instanceof DivExpr
         or
         exists(DivExpr de, Expr ec |
           e2.isConstant() and

--- a/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
@@ -9,21 +9,23 @@ import semmle.code.java.dataflow.ExternalFlow
  * The class `android.database.sqlite.SQLiteDatabase`.
  */
 class TypeSQLiteDatabase extends Class {
-  TypeSQLiteDatabase() { hasQualifiedName("android.database.sqlite", "SQLiteDatabase") }
+  TypeSQLiteDatabase() { this.hasQualifiedName("android.database.sqlite", "SQLiteDatabase") }
 }
 
 /**
  * The class `android.database.sqlite.SQLiteQueryBuilder`.
  */
 class TypeSQLiteQueryBuilder extends Class {
-  TypeSQLiteQueryBuilder() { hasQualifiedName("android.database.sqlite", "SQLiteQueryBuilder") }
+  TypeSQLiteQueryBuilder() {
+    this.hasQualifiedName("android.database.sqlite", "SQLiteQueryBuilder")
+  }
 }
 
 /**
  * The class `android.database.DatabaseUtils`.
  */
 class TypeDatabaseUtils extends Class {
-  TypeDatabaseUtils() { hasQualifiedName("android.database", "DatabaseUtils") }
+  TypeDatabaseUtils() { this.hasQualifiedName("android.database", "DatabaseUtils") }
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll
+++ b/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll
@@ -80,7 +80,7 @@ private class FileSetRedableMethodAccess extends MethodAccess {
   private predicate isCallToSecondArgumentWithValue(boolean value) {
     this.getMethod().getNumberOfParameters() = 1 and value = true
     or
-    isCallWithArgument(1, value)
+    this.isCallWithArgument(1, value)
   }
 
   private predicate isCallWithArgument(int index, boolean arg) {

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -5,7 +5,7 @@
 import javascript
 import semmle.javascript.Promises
 
-/** Provices classes for modelling NoSQL query sinks. */
+/** Provices classes for modeling NoSQL query sinks. */
 module NoSql {
   /** An expression that is interpreted as a NoSQL query. */
   abstract class Query extends Expr {


### PR DESCRIPTION
This PR was written automatically and fixes 10 QL-for-QL results found in `github/codeql`.   

----- 
Patched 8 instances of ql/implicit-this.
- [UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql#L269)
- [UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql#L269)
- [UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql#L269)
- [UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql#L269)
- [SQLite.qll#12](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll#L12)
- [SQLite.qll#19](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll#L19)
- [SQLite.qll#26](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll#L26)
- [TempDirUtils.qll#83](https://github.com/github/codeql/blob/4bf35ad1889ea08b6e3a0797cb019574c62a4329/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll#L83)

Patched 1 instances of ql/non-us-spelling.
- [NoSQL.qll#8](https://github.com/github/codeql/blob/ab403de5625464a8139ae08f5bf4aa79b13a8244/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll#L8)

Patched 1 instances of ql/could-be-cast.
- [DangerousUseOfTransformationAfterOperation.ql#78](https://github.com/github/codeql/blob/8a5fa507b724b32ddceca0bccbfafd9d2a0c27d3/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql#L78)
