### PR TITLE
patching 10 QL-for-QL issues

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql
@@ -266,7 +266,11 @@ class PathElement extends TPathElement {
   predicate isSink(IRBlock block) { exists(this.asSink(block)) }
 
   string toString() {
-    result = [asStore().toString(), asCall(_).toString(), asMid().toString(), asSink(_).toString()]
+    result =
+      [
+        this.asStore().toString(), this.asCall(_).toString(), this.asMid().toString(),
+        this.asSink(_).toString()
+      ]
   }
 
   predicate hasLocationInfo(

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
@@ -75,7 +75,7 @@ predicate signSmallerWithEqualSizes(MulExpr mexp) {
       ae.getRValue().getUnderlyingType().(IntegralType).isUnsigned() and
       ae.getLValue().getUnderlyingType().(IntegralType).isSigned() and
       (
-        not exists(DivExpr de | mexp.getParent*() = de)
+        not mexp.getParent*() instanceof DivExpr
         or
         exists(DivExpr de, Expr ec |
           e2.isConstant() and

--- a/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
@@ -9,21 +9,23 @@ import semmle.code.java.dataflow.ExternalFlow
  * The class `android.database.sqlite.SQLiteDatabase`.
  */
 class TypeSQLiteDatabase extends Class {
-  TypeSQLiteDatabase() { hasQualifiedName("android.database.sqlite", "SQLiteDatabase") }
+  TypeSQLiteDatabase() { this.hasQualifiedName("android.database.sqlite", "SQLiteDatabase") }
 }
 
 /**
  * The class `android.database.sqlite.SQLiteQueryBuilder`.
  */
 class TypeSQLiteQueryBuilder extends Class {
-  TypeSQLiteQueryBuilder() { hasQualifiedName("android.database.sqlite", "SQLiteQueryBuilder") }
+  TypeSQLiteQueryBuilder() {
+    this.hasQualifiedName("android.database.sqlite", "SQLiteQueryBuilder")
+  }
 }
 
 /**
  * The class `android.database.DatabaseUtils`.
  */
 class TypeDatabaseUtils extends Class {
-  TypeDatabaseUtils() { hasQualifiedName("android.database", "DatabaseUtils") }
+  TypeDatabaseUtils() { this.hasQualifiedName("android.database", "DatabaseUtils") }
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll
+++ b/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll
@@ -80,7 +80,7 @@ private class FileSetRedableMethodAccess extends MethodAccess {
   private predicate isCallToSecondArgumentWithValue(boolean value) {
     this.getMethod().getNumberOfParameters() = 1 and value = true
     or
-    isCallWithArgument(1, value)
+    this.isCallWithArgument(1, value)
   }
 
   private predicate isCallWithArgument(int index, boolean arg) {

--- a/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
+++ b/javascript/ql/lib/semmle/javascript/dataflow/Configuration.qll
@@ -1365,27 +1365,31 @@ private predicate loadStep(
 
 /**
  * Holds if there is flow to `base.startProp`, and `base.startProp` flows to `nd.endProp` under `cfg/summary`.
+ *
+ * If `onlyRelevantInCall` is true, the `base` object will not be propagated out of return edges, because
+ * the flow that originally reached `base.startProp` used a call edge.
  */
 pragma[nomagic]
 private predicate reachableFromStoreBase(
   string startProp, string endProp, DataFlow::Node base, DataFlow::Node nd,
-  DataFlow::Configuration cfg, PathSummary summary
+  DataFlow::Configuration cfg, PathSummary summary, boolean onlyRelevantInCall
 ) {
   exists(PathSummary s1, PathSummary s2, DataFlow::Node rhs |
-    reachableFromSource(rhs, cfg, s1)
+    reachableFromSource(rhs, cfg, s1) and
+    onlyRelevantInCall = s1.hasCall()
     or
-    reachableFromStoreBase(_, _, _, rhs, cfg, s1)
+    reachableFromStoreBase(_, _, _, rhs, cfg, s1, onlyRelevantInCall)
   |
     storeStep(rhs, nd, startProp, cfg, s2) and
     endProp = startProp and
     base = nd and
     summary =
-      MkPathSummary(false, s1.hasCall().booleanOr(s2.hasCall()), DataFlow::FlowLabel::data(),
-        DataFlow::FlowLabel::data())
+      MkPathSummary(false, s2.hasCall(), DataFlow::FlowLabel::data(), DataFlow::FlowLabel::data())
   )
   or
   exists(PathSummary newSummary, PathSummary oldSummary |
-    reachableFromStoreBaseStep(startProp, endProp, base, nd, cfg, oldSummary, newSummary) and
+    reachableFromStoreBaseStep(startProp, endProp, base, nd, cfg, oldSummary, newSummary,
+      onlyRelevantInCall) and
     summary = oldSummary.appendValuePreserving(newSummary)
   )
 }
@@ -1399,14 +1403,16 @@ private predicate reachableFromStoreBase(
 pragma[noinline]
 private predicate reachableFromStoreBaseStep(
   string startProp, string endProp, DataFlow::Node base, DataFlow::Node nd,
-  DataFlow::Configuration cfg, PathSummary oldSummary, PathSummary newSummary
+  DataFlow::Configuration cfg, PathSummary oldSummary, PathSummary newSummary,
+  boolean onlyRelevantInCall
 ) {
   exists(DataFlow::Node mid |
-    reachableFromStoreBase(startProp, endProp, base, mid, cfg, oldSummary) and
-    flowStep(mid, cfg, nd, newSummary)
+    reachableFromStoreBase(startProp, endProp, base, mid, cfg, oldSummary, onlyRelevantInCall) and
+    flowStep(mid, cfg, nd, newSummary) and
+    onlyRelevantInCall.booleanAnd(newSummary.hasReturn()) = false
     or
     exists(string midProp |
-      reachableFromStoreBase(startProp, midProp, base, mid, cfg, oldSummary) and
+      reachableFromStoreBase(startProp, midProp, base, mid, cfg, oldSummary, onlyRelevantInCall) and
       isAdditionalLoadStoreStep(mid, nd, midProp, endProp, cfg) and
       newSummary = PathSummary::level()
     )
@@ -1446,7 +1452,7 @@ private predicate storeToLoad(
     PathSummary s1, PathSummary s2
   |
     storeStep(pred, storeBase, storeProp, cfg, s1) and
-    reachableFromStoreBase(storeProp, loadProp, storeBase, loadBase, cfg, s2) and
+    reachableFromStoreBase(storeProp, loadProp, storeBase, loadBase, cfg, s2, _) and
     oldSummary = s1.appendValuePreserving(s2) and
     loadStep(loadBase, succ, loadProp, cfg, newSummary)
   )

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -5,7 +5,7 @@
 import javascript
 import semmle.javascript.Promises
 
-/** Provices classes for modelling NoSQL query sinks. */
+/** Provices classes for modeling NoSQL query sinks. */
 module NoSql {
   /** An expression that is interpreted as a NoSQL query. */
   abstract class Query extends Expr {

--- a/javascript/ql/src/change-notes/2022-03-18-store-load-flow-context-sensitivity-bug.md
+++ b/javascript/ql/src/change-notes/2022-03-18-store-load-flow-context-sensitivity-bug.md
@@ -1,0 +1,6 @@
+---
+category: minorAnalysis
+---
+* Fixed an issue that would sometimes prevent the data-flow analysis from finding flow
+  paths through a function that stores its result on an object.
+  This may lead to more results for the security queries.

--- a/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
+++ b/javascript/ql/test/library-tests/TaintTracking/BasicTaintTracking.expected
@@ -172,6 +172,7 @@ typeInferenceMismatch
 | string-replace.js:3:13:3:20 | source() | string-replace.js:21:6:21:41 | safe(). ...  taint) |
 | string-replace.js:3:13:3:20 | source() | string-replace.js:22:6:22:48 | safe(). ...  taint) |
 | string-replace.js:3:13:3:20 | source() | string-replace.js:24:6:24:45 | taint.r ...  + '!') |
+| summarize-store-load-in-call.js:9:15:9:22 | source() | summarize-store-load-in-call.js:9:10:9:23 | blah(source()) |
 | thisAssignments.js:4:17:4:24 | source() | thisAssignments.js:5:10:5:18 | obj.field |
 | thisAssignments.js:7:19:7:26 | source() | thisAssignments.js:8:10:8:20 | this.field2 |
 | tst.js:2:13:2:20 | source() | tst.js:4:10:4:10 | x |

--- a/javascript/ql/test/library-tests/TaintTracking/summarize-store-load-in-call.js
+++ b/javascript/ql/test/library-tests/TaintTracking/summarize-store-load-in-call.js
@@ -1,0 +1,12 @@
+import * as dummy from 'dummy';
+
+function blah(obj) {
+    obj.prop = obj.prop + "x";
+    return obj.prop;
+}
+
+function test() {
+    sink(blah(source())); // NOT OK
+
+    blah(); // ensure more than one call site exists
+}


### PR DESCRIPTION
This PR was written automatically and fixes 10 QL-for-QL results found in `github/codeql`.   

----- 
Patched 8 instances of `ql/implicit-this`.
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [java/.../SQLite.qll#12](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Flib%2Fsemmle%2Fcode%2Fjava%2Fframeworks%2Fandroid%2FSQLite.qll#L12)
- [java/.../SQLite.qll#19](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Flib%2Fsemmle%2Fcode%2Fjava%2Fframeworks%2Fandroid%2FSQLite.qll#L19)
- [java/.../SQLite.qll#26](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Flib%2Fsemmle%2Fcode%2Fjava%2Fframeworks%2Fandroid%2FSQLite.qll#L26)
- [java/.../TempDirUtils.qll#83](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Fsrc%2FSecurity%2FCWE%2FCWE-200%2FTempDirUtils.qll#L83)

Patched 1 instances of `ql/non-us-spelling`.
- [javascript/.../NoSQL.qll#8](https://github.com/github/codeql/blob/0b279ddfa1acf21b18fa71e55b0c516f43dbb6bb/javascript%2Fql%2Flib%2Fsemmle%2Fjavascript%2Fframeworks%2FNoSQL.qll#L8)

Patched 1 instances of `ql/could-be-cast`.
- [cpp/.../DangerousUseOfTransformationAfterOperation.ql#78](https://github.com/github/codeql/blob/5f0859168f6f562d7d105558d315c4a3b776a802/cpp%2Fql%2Fsrc%2Fexperimental%2FSecurity%2FCWE%2FCWE-190%2FDangerousUseOfTransformationAfterOperation.ql#L78)
