### PR TITLE
patching 10 QL-for-QL issues

### DIFF
--- a/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql
+++ b/cpp/ql/src/Likely Bugs/Memory Management/UsingExpiredStackAddress.ql
@@ -266,7 +266,11 @@ class PathElement extends TPathElement {
   predicate isSink(IRBlock block) { exists(this.asSink(block)) }
 
   string toString() {
-    result = [asStore().toString(), asCall(_).toString(), asMid().toString(), asSink(_).toString()]
+    result =
+      [
+        this.asStore().toString(), this.asCall(_).toString(), this.asMid().toString(),
+        this.asSink(_).toString()
+      ]
   }
 
   predicate hasLocationInfo(

--- a/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
+++ b/cpp/ql/src/experimental/Security/CWE/CWE-190/DangerousUseOfTransformationAfterOperation.ql
@@ -75,7 +75,7 @@ predicate signSmallerWithEqualSizes(MulExpr mexp) {
       ae.getRValue().getUnderlyingType().(IntegralType).isUnsigned() and
       ae.getLValue().getUnderlyingType().(IntegralType).isSigned() and
       (
-        not exists(DivExpr de | mexp.getParent*() = de)
+        not mexp.getParent*() instanceof DivExpr
         or
         exists(DivExpr de, Expr ec |
           e2.isConstant() and

--- a/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
+++ b/java/ql/lib/semmle/code/java/frameworks/android/SQLite.qll
@@ -9,21 +9,23 @@ import semmle.code.java.dataflow.ExternalFlow
  * The class `android.database.sqlite.SQLiteDatabase`.
  */
 class TypeSQLiteDatabase extends Class {
-  TypeSQLiteDatabase() { hasQualifiedName("android.database.sqlite", "SQLiteDatabase") }
+  TypeSQLiteDatabase() { this.hasQualifiedName("android.database.sqlite", "SQLiteDatabase") }
 }
 
 /**
  * The class `android.database.sqlite.SQLiteQueryBuilder`.
  */
 class TypeSQLiteQueryBuilder extends Class {
-  TypeSQLiteQueryBuilder() { hasQualifiedName("android.database.sqlite", "SQLiteQueryBuilder") }
+  TypeSQLiteQueryBuilder() {
+    this.hasQualifiedName("android.database.sqlite", "SQLiteQueryBuilder")
+  }
 }
 
 /**
  * The class `android.database.DatabaseUtils`.
  */
 class TypeDatabaseUtils extends Class {
-  TypeDatabaseUtils() { hasQualifiedName("android.database", "DatabaseUtils") }
+  TypeDatabaseUtils() { this.hasQualifiedName("android.database", "DatabaseUtils") }
 }
 
 /**

--- a/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll
+++ b/java/ql/src/Security/CWE/CWE-200/TempDirUtils.qll
@@ -80,7 +80,7 @@ private class FileSetRedableMethodAccess extends MethodAccess {
   private predicate isCallToSecondArgumentWithValue(boolean value) {
     this.getMethod().getNumberOfParameters() = 1 and value = true
     or
-    isCallWithArgument(1, value)
+    this.isCallWithArgument(1, value)
   }
 
   private predicate isCallWithArgument(int index, boolean arg) {

--- a/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
+++ b/javascript/ql/lib/semmle/javascript/frameworks/NoSQL.qll
@@ -5,7 +5,7 @@
 import javascript
 import semmle.javascript.Promises
 
-/** Provices classes for modelling NoSQL query sinks. */
+/** Provices classes for modeling NoSQL query sinks. */
 module NoSql {
   /** An expression that is interpreted as a NoSQL query. */
   abstract class Query extends Expr {


### PR DESCRIPTION
This PR was written automatically and fixes 10 QL-for-QL results found in `github/codeql`.   

----- 
Patched 8 instances of `ql/implicit-this`.
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [cpp/.../UsingExpiredStackAddress.ql#269](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/cpp%2Fql%2Fsrc%2FLikely%20Bugs%2FMemory%20Management%2FUsingExpiredStackAddress.ql#L269)
- [java/.../SQLite.qll#12](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Flib%2Fsemmle%2Fcode%2Fjava%2Fframeworks%2Fandroid%2FSQLite.qll#L12)
- [java/.../SQLite.qll#19](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Flib%2Fsemmle%2Fcode%2Fjava%2Fframeworks%2Fandroid%2FSQLite.qll#L19)
- [java/.../SQLite.qll#26](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Flib%2Fsemmle%2Fcode%2Fjava%2Fframeworks%2Fandroid%2FSQLite.qll#L26)
- [java/.../TempDirUtils.qll#83](https://github.com/github/codeql/blob/b04c46f96daae1c3224795f7d3fead81d704aa91/java%2Fql%2Fsrc%2FSecurity%2FCWE%2FCWE-200%2FTempDirUtils.qll#L83)

Patched 1 instances of `ql/non-us-spelling`.
- [javascript/.../NoSQL.qll#8](https://github.com/github/codeql/blob/00095cc863575819282b84c21201543458835f65/javascript%2Fql%2Flib%2Fsemmle%2Fjavascript%2Fframeworks%2FNoSQL.qll#L8)

Patched 1 instances of `ql/could-be-cast`.
- [cpp/.../DangerousUseOfTransformationAfterOperation.ql#78](https://github.com/github/codeql/blob/a306e4c6a5df51418265e5e027f8b9e178a55959/cpp%2Fql%2Fsrc%2Fexperimental%2FSecurity%2FCWE%2FCWE-190%2FDangerousUseOfTransformationAfterOperation.ql#L78)
